### PR TITLE
Update Makefile to support cross compile/local install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,61 +17,73 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.  
 #
 
-CC := gcc 
 PROGRAM = raw2fits
 PROGRAM_CLI = raw2fits-cli
 
+PREFIX ?= /usr/
+BIN_PREFIX ?= $(PREFIX)/bin
+SHARE_PREFIX ?= $(PREFIX)/share
+
 DEBUG := -g -ggdb
 
-CFLAGS := -Wall -pipe -I./include -I/usr/include/cfitsio $(DEBUG)
+VPATH := src/
 
-GTKLIB=`pkg-config --cflags --libs gtk+-3.0`
-LIBRAW := -L/usr/lib -lraw
-LIBCONFIG = -lconfig
+LIBS := gtk+-3.0 \
+        libraw \
+        libconfig \
+        cfitsio
 
-LDFLAG := $(LIBRAW) -lm -lcfitsio -export-dynamic -pthread
+CFLAGS += -Wall -pipe -I./include $(DEBUG)
+CFLAGS += $(shell pkg-config --cflags $(LIBS))
 
-SRC_COMMON := src/converter.c src/list.c src/file_utils.c \
-		src/thread_pool.c src/raw2fits.c src/coords_calc.c
-SRC_UI := src/main.c
-SRC_CLI := src/main_cli.c src/config_loader.c
+LDFLAGS += $(shell pkg-config --libs $(LIBS)) -lm -lpthread -export-dynamic
+
+OBJ_COMMON := converter.o \
+              list.o \
+              file_utils.o \
+              thread_pool.o \
+              raw2fits.o \
+              coords_calc.o
+
+OBJ_GUI := main.o
+
+OBJ_CLI := main_cli.o \
+           config_loader.o
 
 all: $(PROGRAM)
 
-$(PROGRAM): $(OBJECTS)
-	$(CC) $(CFLAGS) $(SRC_COMMON) $(SRC_UI) $(GTKLIB) $(LDFLAG) -o $(PROGRAM)
-
+$(PROGRAM): $(OBJ_COMMON) $(OBJ_GUI)
 
 cli: $(PROGRAM_CLI)
 
-$(PROGRAM_CLI): $(OBJECTS)
-	$(CC) $(CFLAGS) $(SRC_COMMON) $(SRC_CLI) $(LIBCONFIG) $(LDFLAG) -o $(PROGRAM_CLI)
-
+$(PROGRAM_CLI): $(OBJ_COMMON) $(OBJ_CLI)
 
 install:
-	mkdir -p /usr/share/raw2fits/
-	cp -f glade/ui.glade /usr/share/raw2fits/
-	cp -f desktop/raw2fits.desktop /usr/share/applications/
-	cp -f glade/raw2fits_48x48.png /usr/share/raw2fits/
-	cp -f glade/raw2fits_128x128.png /usr/share/raw2fits/
-	cp -f glade/raw2fits_48x48.png /usr/share/pixmaps/raw2fits.png
-	cp -f raw2fits /usr/bin
+	mkdir -p $(SHARE_PREFIX)/raw2fits/
+	mkdir -p $(SHARE_PREFIX)/applications/
+	mkdir -p $(SHARE_PREFIX)/pixmaps/
+	cp -f glade/ui.glade $(SHARE_PREFIX)/raw2fits/
+	cp -f desktop/raw2fits.desktop $(SHARE_PREFIX)/applications/
+	cp -f glade/raw2fits_48x48.png $(SHARE_PREFIX)/raw2fits/
+	cp -f glade/raw2fits_128x128.png $(SHARE_PREFIX)/raw2fits/
+	cp -f glade/raw2fits_48x48.png $(SHARE_PREFIX)/pixmaps/raw2fits.png
+	cp -f raw2fits $(BIN_PREFIX)
 
 uninstall:
-	rm -f /usr/bin/raw2fits
-	rm -f /usr/share/pixmaps/raw2fits.png
-	rm -f /usr/share/applications/raw2fits.desktop
-	rm -f /usr/share/raw2fits/raw2fits_48x48.png
-	rm -f /usr/share/raw2fits/raw2fits_128x128.png
-	rm -f /usr/share/raw2fits/ui.glade
-	rm -fr /usr/share/raw2fits/
+	rm -f $(BIN_PREFIX)/raw2fits
+	rm -f $(SHARE_PREFIX)/pixmaps/raw2fits.png
+	rm -f $(SHARE_PREFIX)/applications/raw2fits.desktop
+	rm -f $(SHARE_PREFIX)/raw2fits/raw2fits_48x48.png
+	rm -f $(SHARE_PREFIX)/raw2fits/raw2fits_128x128.png
+	rm -f $(SHARE_PREFIX)/raw2fits/ui.glade
+	rm -fr $(SHARE_PREFIX)/raw2fits/
 
 install-cli:
-	cp -f raw2fits-cli /usr/bin
+	cp -f raw2fits-cli $(BIN_PREFIX)
 
 uninstall-cli:
-	rm -f /usr/bin/raw2fits-cli
+	rm -f $(BIN_PREFIX)/raw2fits-cli
 
 clean:
-	rm -fr $(PROGRAM) $(PROGRAM).o $(PROGRAM_CLI) $(PROGRAM_CLI).o
+	rm -f $(PROGRAM) $(PROGRAM_CLI) $(OBJ_COMMON) $(OBJ_GUI) $(OBJ_CLI)
 

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,15 @@
 PROGRAM = raw2fits
 PROGRAM_CLI = raw2fits-cli
 
-PREFIX ?= /usr/
-BIN_PREFIX ?= $(PREFIX)/bin
-SHARE_PREFIX ?= $(PREFIX)/share
+prefix ?= /usr
+exec_prefix ?= $(prefix)
+bindir ?= $(exec_prefix)/bin
+datarootdir ?= $(prefix)/share
+datadir ?= $(datarootdir)
+
+INSTALL = install
+INSTALL_DATA = ${INSTALL} -m 644
+INSTALL_PROGRAM = $(INSTALL)
 
 DEBUG := -g -ggdb
 
@@ -59,30 +65,27 @@ cli: $(PROGRAM_CLI)
 $(PROGRAM_CLI): $(OBJ_COMMON) $(OBJ_CLI)
 
 install:
-	mkdir -p $(SHARE_PREFIX)/raw2fits/
-	mkdir -p $(SHARE_PREFIX)/applications/
-	mkdir -p $(SHARE_PREFIX)/pixmaps/
-	cp -f glade/ui.glade $(SHARE_PREFIX)/raw2fits/
-	cp -f desktop/raw2fits.desktop $(SHARE_PREFIX)/applications/
-	cp -f glade/raw2fits_48x48.png $(SHARE_PREFIX)/raw2fits/
-	cp -f glade/raw2fits_128x128.png $(SHARE_PREFIX)/raw2fits/
-	cp -f glade/raw2fits_48x48.png $(SHARE_PREFIX)/pixmaps/raw2fits.png
-	cp -f raw2fits $(BIN_PREFIX)
+	$(INSTALL_DATA) -D desktop/raw2fits.desktop $(DESTDIR)$(datadir)/applications/raw2fits.desktop
+	$(INSTALL_DATA) -D glade/raw2fits_128x128.png $(DESTDIR)$(datadir)/raw2fits/aw2fits_128x128.png
+	$(INSTALL_DATA) -D glade/raw2fits_48x48.png $(DESTDIR)$(datadir)/raw2fits/raw2fits_48x48.png
+	$(INSTALL_DATA) -D glade/ui.glade $(DESTDIR)$(datadir)/raw2fits/ui.glade
+	$(INSTALL_DATA) -D glade/raw2fits_48x48.png $(DESTDIR)$(datadir)/pixmaps/raw2fits.png
+	$(INSTALL_PROGRAM) -D raw2fits $(DESTDIR)$(bindir)
 
 uninstall:
-	rm -f $(BIN_PREFIX)/raw2fits
-	rm -f $(SHARE_PREFIX)/pixmaps/raw2fits.png
-	rm -f $(SHARE_PREFIX)/applications/raw2fits.desktop
-	rm -f $(SHARE_PREFIX)/raw2fits/raw2fits_48x48.png
-	rm -f $(SHARE_PREFIX)/raw2fits/raw2fits_128x128.png
-	rm -f $(SHARE_PREFIX)/raw2fits/ui.glade
-	rm -fr $(SHARE_PREFIX)/raw2fits/
+	rm -f $(DESTDIR)$(bindir)/raw2fits
+	rm -f $(DESTDIR)$(datadir)/pixmaps/raw2fits.png
+	rm -f $(DESTDIR)$(datadir)/applications/raw2fits.desktop
+	rm -f $(DESTDIR)$(datadir)/raw2fits/raw2fits_48x48.png
+	rm -f $(DESTDIR)$(datadir)/raw2fits/raw2fits_128x128.png
+	rm -f $(DESTDIR)$(datadir)/raw2fits/ui.glade
+	rm -fr $(DESTDIR)$(datadir)/raw2fits/
 
 install-cli:
-	cp -f raw2fits-cli $(BIN_PREFIX)
+	cp -f raw2fits-cli $(DESTDIR)$(bindir)
 
 uninstall-cli:
-	rm -f $(BIN_PREFIX)/raw2fits-cli
+	rm -f $(DESTDIR)$(bindir)/raw2fits-cli
 
 clean:
 	rm -f $(PROGRAM) $(PROGRAM_CLI) $(OBJ_COMMON) $(OBJ_GUI) $(OBJ_CLI)


### PR DESCRIPTION
I encountered problems targeting an install to a tree within my home directory. Similar issues would occur if cross-compiling or building a package. To resolve this, I have updated the Makefile to conform more closely to the GNU Makefile conventions.